### PR TITLE
Jasper mpdclient improvements and UTF-8 fix

### DIFF
--- a/jasper/i18n.py
+++ b/jasper/i18n.py
@@ -39,7 +39,8 @@ class GettextMixin(object):
         return self.__translations[language]
 
     def gettext(self, *args, **kwargs):
-        return self.__get_translations().gettext(*args, **kwargs)
+        return self.__get_translations().gettext(*args, **kwargs).decode(
+            'utf-8')
 
     def ngettext(self, *args, **kwargs):
         return self.__get_translations().ngettext(*args, **kwargs)

--- a/plugins/speechhandler/mpdcontrol/mpdclient.py
+++ b/plugins/speechhandler/mpdcontrol/mpdclient.py
@@ -13,12 +13,13 @@ PLAYBACK_STATE_STOPPED = 3
 
 
 class MPDClient(object):
-    def __init__(self, server="localhost", port=6600):
+    def __init__(self, server="localhost", port=6600, password=""):
         """
             Prepare the client and music variables
         """
         self._server = server
         self._port = port
+        self._password = password
 
         self._logger = logging.getLogger(__name__)
 
@@ -33,6 +34,7 @@ class MPDClient(object):
         client.idletimeout = None
         try:
             client.connect(self._server, self._port)
+            client.password(self._password)
             yield client
         except (mpd.ConnectionError, socket.error) as e:
             if isinstance(e, socket.error):


### PR DESCRIPTION
- password protected mpd connection now possible
- improved keyword recognition in mpdcontrol by using all keywords found by the stt engine, instead of only the one with highest confidence. "SCHLIESSEN" for example could never be found, as the first hit is always u'SCHLIE\xdfEN'.
- improved recognition for playlist names

unicode fix:
- no errors any more when non-ascii characters as in 'LAUTSTÄRKE' or 'NÄCHSTES LIED' are encountered thanks to utf-8 decoding in i18n.py