### PR TITLE
Convert input to 16kHz if necessary

### DIFF
--- a/jasper/application.py
+++ b/jasper/application.py
@@ -88,7 +88,7 @@ class Jasper(object):
         self._logger.debug("Using Audio engine '%s'", audio_engine_slug)
 
         try:
-            active_stt_slug = self.config['stt_engine']
+            active_stt_slug = self.config['active_stt']['engine']
         except KeyError:
             active_stt_slug = 'sphinx'
             self._logger.warning("stt_engine not specified in profile, " +
@@ -96,7 +96,7 @@ class Jasper(object):
         self._logger.debug("Using STT engine '%s'", active_stt_slug)
 
         try:
-            passive_stt_slug = self.config['stt_passive_engine']
+            passive_stt_slug = self.config['passive_stt']['engine']
         except KeyError:
             passive_stt_slug = active_stt_slug
         self._logger.debug("Using passive STT engine '%s'", passive_stt_slug)
@@ -132,7 +132,7 @@ class Jasper(object):
         devices = [device.slug for device in self.audio.get_devices(
             device_type=audioengine.DEVICE_TYPE_INPUT)]
         try:
-            device_slug = self.config['input_device']
+            device_slug = self.config['audio']['input_device']
         except KeyError:
             device_slug = self.audio.get_default_device(output=False).slug
             self._logger.warning("input_device not specified in profile, " +
@@ -154,7 +154,7 @@ class Jasper(object):
         devices = [device.slug for device in self.audio.get_devices(
             device_type=audioengine.DEVICE_TYPE_OUTPUT)]
         try:
-            device_slug = self.config['output_device']
+            device_slug = self.config['audio']['output_device']
         except KeyError:
             device_slug = self.audio.get_default_device(output=True).slug
             self._logger.warning("output_device not specified in profile, " +
@@ -201,6 +201,12 @@ class Jasper(object):
             'default', self.brain.get_plugin_phrases(), active_stt_plugin_info,
             self.config)
 
+        try:
+            active_stt_plugin._samplerate =\
+                self.config['active_stt']['samplerate']
+        except KeyError:
+            pass
+
         if passive_stt_slug != active_stt_slug:
             passive_stt_plugin_info = self.plugins.get_plugin(
                 passive_stt_slug, category='stt')
@@ -210,6 +216,12 @@ class Jasper(object):
         passive_stt_plugin = passive_stt_plugin_info.plugin_class(
             'keyword', self.brain.get_standard_phrases() + [keyword],
             passive_stt_plugin_info, self.config)
+
+        try:
+            passive_stt_plugin._samplerate =\
+                self.config['passive_stt']['samplerate']
+        except KeyError:
+            pass
 
         tts_plugin_info = self.plugins.get_plugin(tts_slug, category='tts')
         tts_plugin = tts_plugin_info.plugin_class(tts_plugin_info, self.config)

--- a/jasper/mic.py
+++ b/jasper/mic.py
@@ -42,11 +42,7 @@ class Mic(object):
         self._keyword = keyword
         self.tts_engine = tts_engine
         self.passive_stt_engine = passive_stt_engine
-        self.passive_stt_samplerate = get_config_value(
-            config, 'passive_stt_samplerate', 16000)
         self.active_stt_engine = active_stt_engine
-        self.active_stt_samplerate = get_config_value(
-            config, 'active_stt_samplerate', 16000)
         self._input_device = input_device
         self._output_device = output_device
 
@@ -129,9 +125,8 @@ class Mic(object):
     def check_for_keyword(self, frame_queue, keyword_uttered, keyword):
         while True:
             frames = frame_queue.get()
-            with self._write_frames_to_file(frames,
-                                            self.passive_stt_samplerate)\
-                    as f:
+            with self._write_frames_to_file(
+                    frames, self.passive_stt_engine._samplerate) as f:
                 try:
                     transcribed = self.passive_stt_engine.transcribe(f)
                 except:
@@ -223,8 +218,8 @@ class Mic(object):
                     len(frames) > n and self._snr(frames[-n:]) <= 3):
                 break
         self.play_file(paths.data('audio', 'beep_lo.wav'))
-        with self._write_frames_to_file(frames, self.active_stt_samplerate)\
-                as f:
+        with self._write_frames_to_file(
+                frames, self.active_stt_engine._samplerate) as f:
             return self.active_stt_engine.transcribe(f)
 
     # Output methods

--- a/jasper/mic.py
+++ b/jasper/mic.py
@@ -103,8 +103,17 @@ class Mic(object):
             wav_fp = wave.open(f, 'wb')
             wav_fp.setnchannels(self._input_channels)
             wav_fp.setsampwidth(int(self._input_bits/8))
-            wav_fp.setframerate(self._input_rate)
-            wav_fp.writeframes(''.join(frames))
+            wav_fp.setframerate(16000)
+            if self._input_rate == 16000:
+                wav_fp.writeframes(''.join(frames))
+            else:
+                wav_fp.writeframes(audioop.ratecv(''.join(frames),
+                                                  int(self._input_bits/8),
+                                                  self._input_channels,
+                                                  self._input_rate,
+                                                  16000,
+                                                  None)
+                                   [0])
             wav_fp.close()
             f.seek(0)
             yield f

--- a/jasper/plugin.py
+++ b/jasper/plugin.py
@@ -59,6 +59,7 @@ class STTPlugin(GenericPlugin):
         self._vocabulary_name = name
         self._vocabulary_compiled = False
         self._vocabulary_path = None
+        self._samplerate = 16000
 
     def compile_vocabulary(self, compilation_func):
         if self._vocabulary_compiled:

--- a/jasper/populate.py
+++ b/jasper/populate.py
@@ -115,7 +115,7 @@ def run():
                          "implementations: %s. (Press Enter to default " +
                          "to PocketSphinx): " % stt_engines.keys())
     if (response in stt_engines):
-        profile["stt_engine"] = response
+        profile['active_stt'] = {'engine': response}
         api_key_name = stt_engines[response]
         if api_key_name:
             key = raw_input("\nPlease enter your API key: ")
@@ -123,7 +123,7 @@ def run():
     else:
         print("Unrecognized STT engine. Available implementations: %s"
               % stt_engines.keys())
-        profile["stt_engine"] = "sphinx"
+        profile['active_stt'] = {'engine': "sphinx"}
 
     # write to profile
     print("Writing to profile...")


### PR DESCRIPTION
Since the provided language models of cmusphinx are for 16kHz, it does not make sense to use input at another sampling rate. However, setting the recording rate to 16kHz fixed is not an option, because not all microphones support 16kHz recording.
With this fix the recording is converted to 16kHz if it is not already at 16kHz.